### PR TITLE
Fix/file explorer

### DIFF
--- a/fotolyrik_frontend/pages/files.vue
+++ b/fotolyrik_frontend/pages/files.vue
@@ -78,7 +78,7 @@
         <Column field="filename" header="Datei" sortable headerClass="w-[60%]"></Column>
         <Column field="created_date" header="Erstellt am" sortable>
           <template #body="slotProps">
-              {{ timestampToDate(slotProps.data.created_date) }}
+              {{ timestampToDate(slotProps.data.createdDate) }}
           </template>
         </Column>
         <Column class="w-24 !text-end">

--- a/fotolyrik_frontend/stores/FileStore.ts
+++ b/fotolyrik_frontend/stores/FileStore.ts
@@ -72,7 +72,7 @@ export const useFileStore = defineStore("files", () => {
     function getImagePreview(path: string) {
         if (!path) return '';
         const filename = path.split(/[\\/]/).pop() || '';
-        return `${apiClient.defaults.baseURL || ''}/uploads/${filename}`;
+        return `${apiClient.defaults.baseURL || ''}/uploads/${encodeURIComponent(filename)}`;
     }
 
     return {


### PR DESCRIPTION
Fix issues with file explorer frontend:
- update field name for creation date extraction
- allow filenames with url-breaking characters, such as `#`

Closes #27 