### PR TITLE
Frontend. Remove isoDesignation from language names in photopoem form in order to avoid displaying 'null' instead of language name

### DIFF
--- a/fotolyrik_frontend/app/components/forms/PhotopoemForm.vue
+++ b/fotolyrik_frontend/app/components/forms/PhotopoemForm.vue
@@ -32,7 +32,7 @@ const onPersonComplete = (event: any) => {
 const persons = computed(() => personStore.persons.map(p => ({ id: p.id, fullName: p.fullName, studioName: p.studioName, pseudonyms: p.pseudonyms })));
 const keywords = computed(() => keywordStore.keywords.map((k: KeywordDTO) => ({ id: k.id, value: k.value })));
 const languages = computed(() => languageStore.languages.map((l:LanguageDTO) => ({ id: l.id, name: l.name })));
-const files = computed(() => fileStore.files.map((f: FileDTO) => ({ id: f.id, filename: f.filename, originalFilename: f.originalFilename })));
+const files = computed(() => fileStore.files);
 const publicationMedia = computed(() => pubMediumStore.pub_media.map(pm => ({ id: pm.id, title: pm.title })));
 const locations = computed(()=> locationStore.locations.map(l=>({id: l.id, name: l.name}) ));
 const copyrightStatuses = computed(() => copyrightStatusStore.copyrightStatuses.map(cs => ({ id: cs.id, value: cs.value })));
@@ -548,8 +548,8 @@ const onFormSubmit = async (e: any) => {
                 optionLabel="originalFilename"
                 :virtual-scroller-options="{ itemSize: 50 }"
                 :key="files.length"
-                :maxSelectedLabels="2"
-                fluid filter
+                :maxSelectedLabels="3"
+                fluid filter showClear
             >
               <template #option="slotProps">
                 <div class="flex flex-row space-x-2">

--- a/fotolyrik_frontend/app/components/forms/PhotopoemForm.vue
+++ b/fotolyrik_frontend/app/components/forms/PhotopoemForm.vue
@@ -548,7 +548,7 @@ const onFormSubmit = async (e: any) => {
                 optionLabel="originalFilename"
                 :virtual-scroller-options="{ itemSize: 50 }"
                 :key="files.length"
-                :maxSelectedLabels="3"
+                :maxSelectedLabels="2"
                 fluid filter showClear
             >
               <template #option="slotProps">

--- a/fotolyrik_frontend/app/components/forms/PhotopoemForm.vue
+++ b/fotolyrik_frontend/app/components/forms/PhotopoemForm.vue
@@ -31,7 +31,7 @@ const onPersonComplete = (event: any) => {
 
 const persons = computed(() => personStore.persons.map(p => ({ id: p.id, fullName: p.fullName, studioName: p.studioName, pseudonyms: p.pseudonyms })));
 const keywords = computed(() => keywordStore.keywords.map((k: KeywordDTO) => ({ id: k.id, value: k.value })));
-const languages = computed(() => languageStore.languages.map((l:LanguageDTO) => ({ id: l.id, name: l.name, isoDesignation: l.isoDesignation })));
+const languages = computed(() => languageStore.languages.map((l:LanguageDTO) => ({ id: l.id, name: l.name })));
 const files = computed(() => fileStore.files.map((f: FileDTO) => ({ id: f.id, filename: f.filename, originalFilename: f.originalFilename })));
 const publicationMedia = computed(() => pubMediumStore.pub_media.map(pm => ({ id: pm.id, title: pm.title })));
 const locations = computed(()=> locationStore.locations.map(l=>({id: l.id, name: l.name}) ));
@@ -284,7 +284,7 @@ const onFormSubmit = async (e: any) => {
           <FormField v-slot="$field" name="languages" class="flex flex-col gap-1 w-full">
             <label for="languages" class="font-bold">Sprache(n)</label>
             <MultiSelect
-                inputId="authors"
+                inputId="languages"
                 placeholder="Sprachen auswählen"
                 selectedItemsLabel="{0} Sprachen ausgewählt"
                 optionLabel="name"


### PR DESCRIPTION
Closes #98